### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "laravel/framework": "^9.46|^10.10|^11.0|^12.0"
+        "laravel/framework": "^9.46|^10.10|^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "laravel/pint": "^1.14",


### PR DESCRIPTION
## Summary
- Add `^13.0` to `laravel/framework` constraint in `composer.json`
- No source code changes required — all APIs used are stable across Laravel 13

## What's Changed
Laravel 13 support in composer.json:
Now supports `^9.46|^10.10|^11.0|^12.0|^13.0`